### PR TITLE
Fix missing kernel-pae-devel for f22

### DIFF
--- a/http/ks-fedora22.cfg
+++ b/http/ks-fedora22.cfg
@@ -48,6 +48,7 @@ reboot
 # Not sure how to specify these packages in a kickstart
 # gcc
 # gcc-c++
+# kernel-pae-devel
 # openssl-devel
 # patch
 # readline-devel
@@ -56,7 +57,6 @@ reboot
 curl
 bzip2
 deltarpm
-kernel-pae-devel
 kernel-devel
 kernel-headers
 make

--- a/script/vmtool.sh
+++ b/script/vmtool.sh
@@ -12,7 +12,8 @@ if [[ $PACKER_BUILDER_TYPE =~ vmware ]]; then
     # from the install media via ks.cfg
     # Except on Fedora 22 (which uses dnf)
     if [ "${PKG_MGR}" == "dnf" ]; then
-        ${PKG_MGR} -y install kernel-headers-$(uname -r) kernel-devel-$(uname -r) gcc make perl
+        ${PKG_MGR} -y install kernel-headers-$(uname -r) \
+                   kernel-devel-$(uname -r) kernel-pae-devel gcc make perl
     fi
 
     cd /tmp


### PR DESCRIPTION
kernel-pae-devel doesn't appear to be installable via kickstart.
Install it during vmtools installation instead.
