### PR TITLE
Support disabling CNDN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ ifndef CM_VERSION
 	endif
 endif
 BOX_VERSION ?= $(shell cat VERSION)
+DISABLE_CNDN ?= false
 DISK_SIZE ?= 10140
 SSH_USERNAME ?= vagrant
 SSH_PASSWORD ?= vagrant
@@ -28,7 +29,7 @@ endif
 HEADLESS ?= false
 UPDATE ?= false
 # Packer does not allow empty variables, so only pass variables that are defined
-PACKER_VARS_LIST = 'cm=$(CM)' 'headless=$(HEADLESS)' 'update=$(UPDATE)' 'version=$(BOX_VERSION)' 'ssh_username=$(SSH_USERNAME)' 'ssh_password=$(SSH_PASSWORD)' 'install_vagrant_key=$(INSTALL_VAGRANT_KEY)' 'disk_size=${DISK_SIZE}'  'iso_path=$(ISO_PATH)'
+PACKER_VARS_LIST = 'cm=$(CM)' 'headless=$(HEADLESS)' 'update=$(UPDATE)' 'version=$(BOX_VERSION)' 'ssh_username=$(SSH_USERNAME)' 'ssh_password=$(SSH_PASSWORD)' 'install_vagrant_key=$(INSTALL_VAGRANT_KEY)' 'disk_size=${DISK_SIZE}'  'iso_path=$(ISO_PATH)' 'disable_cndn=$(DISABLE_CNDN)'
 ifdef CM_VERSION
 	PACKER_VARS_LIST += 'cm_version=$(CM_VERSION)'
 endif

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ configuration management tool, to override the default of `latest`.
 The value of `CM_VERSION` should have the form `x.y` or `x.y.z`,
 such as `CM_VERSION := 11.12.4`
 
+The variable `DISABLE_CNDN` can be set to disable the use of
+Consistent Network Device Names (CNDN) so that network interfaces are
+named eth[1-9].  Set `DISABLE_CNDN := true`, the default is false.
+
 The variable `UPDATE` can be used to perform OS patch management.  The
 default is to not apply OS updates by default.  When `UPDATE := true`,
 the latest OS updates will be applied.

--- a/fedora22.json
+++ b/fedora22.json
@@ -119,6 +119,7 @@
       "environment_vars": [
         "CM={{user `cm`}}",
         "CM_VERSION={{user `cm_version`}}",
+        "DISABLE_CNDN={{user `disable_cndn`}}",
         "UPDATE={{user `update`}}",
         "INSTALL_VAGRANT_KEY={{user `install_vagrant_key`}}",
         "PKG_MGR={{user `pkg_mgr`}}",
@@ -145,6 +146,7 @@
   "variables": {
     "cm": "nocm",
     "cm_version": "",
+    "disable_cndn": "{{env `disable_cndn`}}",
     "disk_size": "10140",
     "ftp_proxy": "{{env `ftp_proxy`}}",
     "headless": "",

--- a/script/update.sh
+++ b/script/update.sh
@@ -3,6 +3,13 @@ if [[ $UPDATE  =~ true || $UPDATE =~ 1 || $UPDATE =~ yes ]]; then
     echo "==> Applying updates"
     yum -y update
 
+    if [ "$DISABLE_CNDN" = "true" ]; then
+        echo "==> Disabling consistent network device names"
+        sed -i 's/^\(GRUB_CMDLINE_LINUX=".*\)"/\1 net.ifnames=0"/' \
+            /etc/default/grub
+        grub2-mkconfig -o /boot/grub2/grub.cfg
+    fi
+
     # reboot
     echo "Rebooting the machine..."
     reboot


### PR DESCRIPTION
Fedora enables Consistent Network Device Naming (CNDN) by default.  This
change adds support for disabling CNDN by setting the DISABLE_CNDN
variable.
