### PR TITLE
Fix kickstart for f22

### DIFF
--- a/http/ks-fedora22.cfg
+++ b/http/ks-fedora22.cfg
@@ -56,7 +56,6 @@ reboot
 curl
 bzip2
 deltarpm
-kernel-pae-devel
 kernel-devel
 kernel-headers
 make


### PR DESCRIPTION
It's not possible to install kernel-pae-devel for x86_64 since it is
only valid for 32-bit systems.  This change ensures that the f22
kickstart file no longer tries to install kernel-pae-devel to avoid
breaking x86_64 builds.
