### PR TITLE
Install yum-utils in f22 kickstart for ansible

### DIFF
--- a/http/ks-fedora22.cfg
+++ b/http/ks-fedora22.cfg
@@ -67,6 +67,9 @@ tar
 wget
 zlib-devel
 nfs-utils
+
+# Requirement for ansible package installation
+yum-utils
 %end
 
 %post


### PR DESCRIPTION
Installing packages via ansible on Fedora 22 requires that the yum-utils
package be explicitly installed.
