### PR TITLE
Add support for Fedora 26 Server and Workstation

### DIFF
--- a/fedora26-server.json
+++ b/fedora26-server.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Build with `packer build -var-file=fedora26-server.json fedora.json`",
+  "vm_name": "fedora26-server",
+  "cpus": "1",
+  "disk_size": "65536",
+  "iso_checksum": "fad18a43b9cec152fc8a1fd368950eaf59be66b1a15438149a0c3a509c56cf2f",
+  "iso_checksum_type": "sha256",
+  "iso_name": "Fedora-Server-dvd-x86_64-26-1.5.iso",
+  "iso_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Server/x86_64/iso/Fedora-Server-dvd-x86_64-26-1.5.iso",
+  "kickstart": "ks-fedora26-server.cfg",
+  "memory": "2048"
+}

--- a/fedora26-ws.json
+++ b/fedora26-ws.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Build with `packer build -var-file=fedora26-ws.json fedora.json`",
+  "vm_name": "fedora26-ws",
+  "cpus": "1",
+  "disk_size": "65536",
+  "iso_checksum": "f514040516dc512119aad6316746569b231e157724d4f257af76825c483e1598",
+  "iso_checksum_type": "sha256",
+  "iso_name": "Fedora-Workstation-netinst-x86_64-26-1.5.iso",
+  "iso_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Workstation/x86_64/iso/Fedora-Workstation-netinst-x86_64-26-1.5.iso",
+  "kickstart": "ks-fedora26-ws.cfg",
+  "memory": "2048"
+}

--- a/http/ks-fedora26-server.cfg
+++ b/http/ks-fedora26-server.cfg
@@ -1,0 +1,80 @@
+# Fedora 26 Server kickstart file - ks.cfg
+#
+# For more information on kickstart syntax and commands, refer to the
+# Fedora Installation Guide:
+# https://docs.fedoraproject.org/f26/install-guide/appendixes/Kickstart_Syntax_Reference.html#appe-kickstart-syntax-reference
+# Or:
+# http://pykickstart.readthedocs.io/en/latest/kickstart-docs.html#chapter-2-kickstart-commands-in-fedora
+
+#
+# For testing, you can fire up a local http server temporarily.
+# cd to the directory where this ks.cfg file resides and run the following:
+#    $ python -m SimpleHTTPServer
+# You don't have to restart the server every time you make changes.  Python
+# will reload the file from disk every time.  As long as you save your changes
+# they will be reflected in the next HTTP download.  Then to test with
+# a PXE boot server, enter the following on the PXE boot prompt:
+#    > linux text ks=http://<your_ip>:8000/ks.cfg
+
+# Required settings
+lang en_US.UTF-8
+keyboard 'us'
+rootpw vagrant
+auth --enableshadow --passalgo=sha512
+timezone UTC
+
+# Optional settings
+install
+cdrom
+network --bootproto=dhcp
+selinux --disabled
+firewall --disabled
+
+# Avoiding warning message on Storage device breaking automated generation
+zerombr
+
+# Remove all existing partitions
+clearpart --all --initlabel
+
+autopart
+
+# Reboot After Installation
+reboot --eject
+
+%packages
+@core
+# The following packages do not load in a kickstart on Fedora 26 - say package not found or throw package conflicts
+# gcc
+# gcc-c++
+# openssl-devel
+# patch
+# readline-devel
+# sqlite-devel
+# zlib-devel
+# Prerequisites for installing VMware Tools or VirtualBox guest additions.
+bzip2
+curl
+deltarpm
+kernel-devel
+kernel-headers
+make
+net-tools
+nfs-utils
+perl
+rsync
+sudo
+tar
+wget
+%end
+
+%post
+# Add Vagrant user and group.
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant
+echo "vagrant"|passwd --stdin vagrant
+
+# Give Vagrant user permission to sudo.
+echo 'Defaults:vagrant !requiretty' > /etc/sudoers.d/vagrant
+echo '%vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/vagrant
+chmod 440 /etc/sudoers.d/vagrant
+%end

--- a/http/ks-fedora26-ws.cfg
+++ b/http/ks-fedora26-ws.cfg
@@ -1,0 +1,105 @@
+# Fedora 26 Workstation kickstart file - ks.cfg
+#
+# For more information on kickstart syntax and commands, refer to the
+# Fedora Installation Guide:
+# https://docs.fedoraproject.org/f26/install-guide/appendixes/Kickstart_Syntax_Reference.html#appe-kickstart-syntax-reference
+# Or:
+# http://pykickstart.readthedocs.io/en/latest/kickstart-docs.html#chapter-2-kickstart-commands-in-fedora
+
+#
+# For testing, you can fire up a local http server temporarily.
+# cd to the directory where this ks.cfg file resides and run the following:
+#    $ python -m SimpleHTTPServer
+# You don't have to restart the server every time you make changes.  Python
+# will reload the file from disk every time.  As long as you save your changes
+# they will be reflected in the next HTTP download.  Then to test with
+# a PXE boot server, enter the following on the PXE boot prompt:
+#    > linux text ks=http://<your_ip>:8000/ks.cfg
+
+# Required settings
+lang en_US.UTF-8
+keyboard 'us'
+rootpw vagrant
+auth --enableshadow --passalgo=sha512
+timezone UTC
+
+# Optional settings
+install
+# cdrom
+# use a Fedora mirror for the install source
+url --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
+network --bootproto=dhcp
+selinux --disabled
+firewall --disabled
+
+# Avoiding warning message on Storage device breaking automated generation
+zerombr
+
+# Remove all existing partitions
+clearpart --all --initlabel
+
+autopart
+
+# Reboot After Installation
+reboot --eject
+
+%packages
+@core
+# Install the default GNOME desktop
+@base-x
+@firefox
+@fonts
+@gnome-desktop
+@hardware-support
+@input-methods
+@libreoffice
+@multimedia
+@networkmanager-submodules
+@printing
+@standard
+@workstation-product
+# -gfs2-utils
+# -reiserfs-utils
+# The following packages do not load in a kickstart on Fedora 26 - say package not found or throw package conflicts
+# gcc
+# gcc-c++
+# openssl-devel
+# patch
+# readline-devel
+# sqlite-devel
+# zlib-devel
+# Prerequisites for installing VMware Tools or VirtualBox guest additions.
+bzip2
+curl
+deltarpm
+kernel-devel
+kernel-headers
+make
+net-tools
+nfs-utils
+perl
+rsync
+sudo
+tar
+wget
+%end
+
+%post
+# Add Vagrant user and group.
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant
+echo "vagrant"|passwd --stdin vagrant
+
+# Give Vagrant user permission to sudo.
+echo 'Defaults:vagrant !requiretty' > /etc/sudoers.d/vagrant
+echo '%vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/vagrant
+chmod 440 /etc/sudoers.d/vagrant
+
+# Enable SSHd for Packer provisioning
+systemctl enable sshd.service
+
+# Enable the GUI at startup
+systemctl enable gdm.service
+systemctl set-default graphical.target
+
+%end

--- a/script/virtualbox.sh
+++ b/script/virtualbox.sh
@@ -5,15 +5,15 @@ SSH_USER_HOME=${SSH_USER_HOME:-/home/${SSH_USER}}
 
 if [[ $PACKER_BUILDER_TYPE =~ virtualbox ]]; then
     echo "==> Installing VirtualBox guest additions"
-    dnf -y install kernel-headers-$(uname -r) kernel-devel-$(uname -r) gcc make perl
-
+    # Some of these packages should already have been installed in the kickstart
+    dnf -y install kernel-headers-"$(uname -r)" kernel-devel-"$(uname -r)" gcc make perl
+    # Need to set the KERN_DIR in Fedora 26 and 27 or the VBox additions will not install
+    /usr/libexec/system-python -mplatform | grep -qi "fedora-2[67]" && echo "Fedora 26 or 27 detected" && \
+    KERN_DIR=/usr/src/kernels/"$(uname -r)" && export KERN_DIR
     VBOX_VERSION=$(cat $SSH_USER_HOME/.vbox_version)
     mount -o loop $SSH_USER_HOME/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
     sh /mnt/VBoxLinuxAdditions.run --nox11
     umount /mnt
     rm -rf $SSH_USER_HOME/VBoxGuestAdditions_$VBOX_VERSION.iso
     rm -f $SSH_USER_HOME/.vbox_version
-
-    echo "==> Removing packages needed for building guest tools"
-    dnf -y remove gcc cpp kernel-devel kernel-headers perl
 fi


### PR DESCRIPTION
This PR adds basic support for Fedora Server 26.
I have tested with VirtualBox but not with Parallels or VMware as I do not have access to them at this time.
I cleaned up the kickstart file a bit and sorted the packages alphabetically.
I removed the `dnf remove` line in `script/virtualbox.sh` as this was removing base packages that will in all likelihood have to be reinstalled again by the user do to any dev work such as `cpp` and `perl`.
The VirtualBox guest additions would not install without the `KERN_DIR` env var being set.
I intend to add a separate Fedora 26 Workstation box so I appended the files with `-server`.