### PR TITLE
Add support for Packer 1.1: set expect_disconnect to true.

### DIFF
--- a/fedora.json
+++ b/fedora.json
@@ -119,7 +119,8 @@
         "custom-script.sh",
         "script/cleanup.sh"
       ],
-      "type": "shell"
+      "type": "shell",
+      "expect_disconnect": "true"
     }
   ],
   "variables": {
@@ -149,4 +150,3 @@
     "vmware_guest_os_type": "fedora-64"
   }
 }
-


### PR DESCRIPTION
Otherwise update.sh will fail because the reboot disconnects and then packer bails out (see https://github.com/hashicorp/packer/blob/master/CHANGELOG.md#backwards-incompatibilities).