### PR TITLE
update fedora 26 target url

### DIFF
--- a/fedora26-server.json
+++ b/fedora26-server.json
@@ -6,7 +6,7 @@
   "iso_checksum": "fad18a43b9cec152fc8a1fd368950eaf59be66b1a15438149a0c3a509c56cf2f",
   "iso_checksum_type": "sha256",
   "iso_name": "Fedora-Server-dvd-x86_64-26-1.5.iso",
-  "iso_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Server/x86_64/iso/Fedora-Server-dvd-x86_64-26-1.5.iso",
+  "iso_url": "https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/26/Server/x86_64/iso/Fedora-Server-dvd-x86_64-26-1.5.iso",
   "kickstart": "ks-fedora26-server.cfg",
   "memory": "2048"
 }

--- a/fedora26-ws.json
+++ b/fedora26-ws.json
@@ -6,7 +6,7 @@
   "iso_checksum": "f514040516dc512119aad6316746569b231e157724d4f257af76825c483e1598",
   "iso_checksum_type": "sha256",
   "iso_name": "Fedora-Workstation-netinst-x86_64-26-1.5.iso",
-  "iso_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Workstation/x86_64/iso/Fedora-Workstation-netinst-x86_64-26-1.5.iso",
+  "iso_url": "https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/26/Workstation/x86_64/iso/Fedora-Workstation-netinst-x86_64-26-1.5.iso",
   "kickstart": "ks-fedora26-ws.cfg",
   "memory": "2048"
 }


### PR DESCRIPTION
Fedora 26 is no longer available in the primary download server.

This updates the urls to pull from https://archives.fedoraproject.org/pub/archive/fedora.